### PR TITLE
feat: apply orange and white theme

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -10,18 +10,18 @@
     --otnt-primary-ultra-light: #fff5f0;
     --otnt-orange: #ff6b35;
     --otnt-orange-light: #f7931e;
-    
-    --otnt-secondary: #1e3a8a;
-    --otnt-secondary-dark: #1e40af;
-    --otnt-secondary-light: #3b82f6;
-    --otnt-secondary-ultra-light: #eff6ff;
+
+    --otnt-secondary: #f36c21;
+    --otnt-secondary-dark: #e55a1f;
+    --otnt-secondary-light: #ff8c42;
+    --otnt-secondary-ultra-light: #fff5f0;
     
     /* ===== ACCENT COLORS ===== */
     --otnt-accent: #ffefe6;
-    --otnt-accent-1: #6f42c1;
-    --otnt-accent-2: #e83e8c;
+    --otnt-accent-1: #ffcc99;
+    --otnt-accent-2: #ffb366;
     --otnt-accent-3: #fd7e14;
-    --otnt-accent-4: #20c997;
+    --otnt-accent-4: #ffe6cc;
     
     /* ===== STATUS COLORS ===== */
     --otnt-success: #28a745;
@@ -46,8 +46,8 @@
     --otnt-bg-accent: #fff5f0;
     --otnt-bg-card: #ffffff;
     --otnt-bg-sidebar: #f8fafc;
-    --otnt-bg-footer: #1a202c;
-    --otnt-bg-footer-light: #2d3748;
+    --otnt-bg-footer: #e55a1f;
+    --otnt-bg-footer-light: #f36c21;
     --otnt-bg-section: #f7fafc;
     --otnt-bg-alternate: #edf2f7;
     
@@ -440,7 +440,7 @@ body::before {
 }
 
 .menu-link i:first-child {
-    color: var(--otnt-secondary);
+    color: var(--otnt-primary);
     margin-right: 12px;
     width: 20px;
     text-align: center;
@@ -568,7 +568,7 @@ body::before {
 .logo-title {
     font-size: 28px;
     font-weight: 800;
-    color: var(--otnt-secondary);
+    color: var(--otnt-primary);
     line-height: 1;
     letter-spacing: 2px;
 }
@@ -672,7 +672,7 @@ body::before {
 .action-link i {
     font-size: 20px;
     margin-bottom: 4px;
-    color: var(--otnt-secondary);
+    color: var(--otnt-primary);
 }
 
 .action-link span {
@@ -701,7 +701,7 @@ body::before {
 }
 
 .header-top {
-    background: linear-gradient(135deg, var(--otnt-secondary) 0%, var(--otnt-secondary-dark) 100%);
+    background: linear-gradient(135deg, var(--otnt-primary) 0%, var(--otnt-primary-dark) 100%);
     color: var(--otnt-white);
     padding: 12px 0;
     font-size: 14px;
@@ -711,7 +711,7 @@ body::before {
 
 /* ===== TOP BAR STYLES ===== */
 .top-bar {
-    background: linear-gradient(135deg, var(--otnt-secondary) 0%, var(--otnt-secondary-dark) 100%);
+    background: linear-gradient(135deg, var(--otnt-primary) 0%, var(--otnt-primary-dark) 100%);
     color: var(--otnt-white);
     padding: 12px 0;
     font-size: 14px;
@@ -854,7 +854,7 @@ body::before {
 /* ===== HERO SECTION ===== */
 .hero-section {
     padding: var(--otnt-spacing-lg) 0;
-    background: linear-gradient(135deg, var(--otnt-secondary) 0%, var(--otnt-primary) 100%);
+    background: linear-gradient(135deg, var(--otnt-primary-light) 0%, var(--otnt-primary) 100%);
 }
 
 .hero-grid {
@@ -1492,7 +1492,7 @@ html body .site-footer {
     transform: translateX(-50%);
     width: 100px;
     height: 2px;
-    background: linear-gradient(90deg, #667eea, #764ba2);
+    background: linear-gradient(90deg, var(--otnt-primary), var(--otnt-primary-light));
     border-radius: 1px;
 }
 

--- a/assets/css/single-product.css
+++ b/assets/css/single-product.css
@@ -5,7 +5,7 @@
 :root {
     --otnt-primary: #f36c21;
     --otnt-primary-dark: #e55a1f;
-    --otnt-secondary: #1e3a8a;
+    --otnt-secondary: #ff8c42;
     --otnt-accent: #ffefe6;
     --otnt-text: #2c3e50;
     --otnt-muted: #7f8c8d;

--- a/footer.php
+++ b/footer.php
@@ -2,7 +2,7 @@
     </main><!-- .main-content -->
 
     <!-- Site Footer -->
-    <footer class="site-footer" role="contentinfo">
+    <footer class="site-footer" role="contentinfo" style="background: linear-gradient(135deg, var(--otnt-primary-dark), var(--otnt-primary)); color: var(--otnt-text-inverse);">
         <div class="container">
             <!-- After Sales Support Section -->
             <div class="after-sales-support">

--- a/header.php
+++ b/header.php
@@ -45,11 +45,11 @@
     </style>
 </head>
 
-<body <?php body_class(); ?>>
+<body <?php body_class('orange-theme'); ?>>
     <?php wp_body_open(); ?>
-    
+
     <!-- Top Bar -->
-    <div class="top-bar">
+    <div class="top-bar" style="background: var(--color-primary); color: var(--color-white);">
         <div class="container">
             <div class="top-bar-left">
                 <div class="top-bar-item">

--- a/index.php
+++ b/index.php
@@ -9,7 +9,7 @@
 get_header(); ?>
 
 <!-- Main Content -->
-<main class="main-content" id="main-content">
+<main class="main-content" id="main-content" style="background: var(--color-white);">
     <div class="container">
         
         <!-- Enhanced Icons Row Section -->

--- a/style.css
+++ b/style.css
@@ -11,23 +11,22 @@ Text Domain: scode-theme
 :root {
     /* ===== ENHANCED COLOR SYSTEM ===== */
     /* Primary Brand Colors - Modern Orange Gradient */
-    --color-primary: #ff6b35;
-    --color-primary-light: #ff8a65;
-    --color-primary-dark: #e55a1a;
-    --color-primary-gradient: linear-gradient(135deg, #ff6b35, #ff8a65);
-    
-    /* Secondary Colors - Modern Blue */
-    --color-secondary: #4f46e5;
-    --color-secondary-light: #6366f1;
-    --color-secondary-dark: #3730a3;
-    
-    /* Accent Colors - Purple & Teal */
-    --color-accent: #8b5cf6;
-    --color-accent-light: #a78bfa;
-    --color-accent-dark: #7c3aed;
-    --color-purple: #7c3aed;
-    --color-teal: #06b6d4;
-    --color-teal-light: #22d3ee;
+    --color-primary: #f47920;
+    --color-primary-light: #ff8f4c;
+    --color-primary-dark: #d65e0e;
+    --color-primary-gradient: linear-gradient(135deg, #f47920, #ff8f4c);
+
+    /* Secondary & Accent Colors - Orange Variations */
+    --color-secondary: #ffa94d;
+    --color-secondary-light: #ffd8a8;
+    --color-secondary-dark: #e68a00;
+
+    --color-accent: #ffcc99;
+    --color-accent-light: #ffe6cc;
+    --color-accent-dark: #d9874a;
+    --color-purple: #ffcc99;
+    --color-teal: #ffb84d;
+    --color-teal-light: #ffe6cc;
     
     /* Neutral Colors - Modern Gray Scale */
     --color-white: #ffffff;
@@ -265,7 +264,7 @@ a:hover {
 
 /* ===== TOP BAR STYLES ===== */
 .top-bar {
-    background-color: var(--color-dark);
+    background-color: var(--color-primary);
     color: var(--color-white);
     padding: var(--spacing-8) 0;
     font-size: 0.875rem;
@@ -466,7 +465,7 @@ a:hover {
 }
 
 .vertical-mega-menu {
-    background: var(--color-dark);
+    background: var(--color-primary-dark);
     border-radius: var(--radius);
     overflow: hidden;
     box-shadow: var(--shadow-lg);
@@ -1063,7 +1062,7 @@ a:hover {
     font-weight: 500;
     text-transform: uppercase;
     letter-spacing: 0.5px;
-    color: var(--color-dark);
+    color: var(--color-primary-dark);
     text-align: center;
     max-width: 140px;
     line-height: 1.2;
@@ -6558,7 +6557,7 @@ body.video-modal-open {
     top: 50px;
     right: 12px;
     background: var(--color-warning);
-    color: var(--color-dark);
+    color: var(--color-primary-dark);
     padding: 6px 12px;
     border-radius: 20px;
     font-size: 0.875rem;


### PR DESCRIPTION
## Summary
- switch root color variables to an orange and white palette inspired by MiVietnam
- style top bars, header, hero section and footer with the new orange gradient
- apply the orange scheme to single-product and main layouts

## Testing
- `php -l index.php header.php footer.php`


------
https://chatgpt.com/codex/tasks/task_e_68acb7c985388321bd135870d2d0f1ab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated the site to an orange-primary color theme, replacing blue accents.
  - Refreshed gradients and backgrounds across header, footer, hero, and main content.
  - Unified text, icons, badges, separators, and menu elements to use new primary tokens.
  - Introduced an “orange-theme” body class for consistent styling.
  - Applied inline styles to top bar and footer to reflect the new palette.
  - Aligned single-product and global styles to the updated color variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->